### PR TITLE
Build driver against Linux kernel >= 4.8.0

### DIFF
--- a/include/rtw_wifi_regd.h
+++ b/include/rtw_wifi_regd.h
@@ -7,6 +7,13 @@
 #ifndef __RTW_WIFI_REGD_H__
 #define __RTW_WIFI_REGD_H__
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0))
+#define IEEE80211_BAND_2GHZ NL80211_BAND_2GHZ
+#define IEEE80211_BAND_5GHZ NL80211_BAND_5GHZ
+#define ieee80211_band nl80211_band
+#define IEEE80211_NUM_BANDS 2
+#endif
+
 struct country_code_to_enum_rd {
 	u16 countrycode;
 	const char *iso_name;

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -1866,7 +1866,16 @@ void rtw_cfg80211_indicate_scan_done(_adapter *adapter, bool aborted)
 		if (pwdev_priv->scan_request->wiphy != pwdev_priv->rtw_wdev->wiphy)
 			RTW_INFO("error wiphy compare\n");
 		else
-			cfg80211_scan_done(pwdev_priv->scan_request, aborted);
+		{
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0))
+                        struct cfg80211_scan_info info = {
+                                .aborted = aborted,
+                        };
+                        cfg80211_scan_done(pwdev_priv->scan_request, &info);
+#else
+                        cfg80211_scan_done(pwdev_priv->scan_request, aborted);
+#endif	
+		}
 
 		pwdev_priv->scan_request = NULL;
 	} else {


### PR DESCRIPTION
A few symbols were renamed and a function parameter list changed, preventing the driver from building.